### PR TITLE
Fix buffer overflow bug in path construction

### DIFF
--- a/src/notebook.c
+++ b/src/notebook.c
@@ -26,9 +26,7 @@ void set_notebook(GtkWidget* notebook, const char* file_name, const char* path_n
     char             location[1024];
     bool             contents_loaded = false;
 
-    strcpy(location, path_name);
-    strcat(location,"/");
-    strcat(location,file_name);
+    snprintf(location, sizeof(location), "%s/%s", path_name, file_name);
 
     file = g_file_new_for_path(location);
     

--- a/src/utils.c
+++ b/src/utils.c
@@ -21,9 +21,7 @@ int filling_list(PATH* paths, char* file_name){
             if (entry->d_name[0] == '.')
                 continue;
 
-            strcpy(path, file_name);
-            strcat(path, "/");
-            strcat(path, entry->d_name);
+            snprintf(path, sizeof(path), "%s/%s", file_name, entry->d_name);
 
             //printf("entry: %s\n", path);
 


### PR DESCRIPTION
## Summary
This PR fixes a potential buffer overflow in `notebook.c` and `utils.c`
by replacing unsafe string operations with a bounded `snprintf` call.

## Bug
File paths were constructed using `strcpy` and `strcat` without
checking buffer boundaries, which could lead to a buffer overflow.

## Fix
Replaced the string copy and concatenation logic with `snprintf`
to safely construct the path within the buffer size.

## Fixed Files
- notebook.c
- utils.c
